### PR TITLE
Fewer conformance levels, require justification of claims

### DIFF
--- a/core/baseline-core-v1.0-psd01.md
+++ b/core/baseline-core-v1.0-psd01.md
@@ -2905,15 +2905,18 @@ A standardized set of test-fixtures with test inputs for all MUST, SHOULD, and M
 
 ## 9.2 Conformance Levels
 
-This section specifies the conformance levels of this standard. The conformance levels aim to enable implementers several levels of conformance to establish competitive differentiation.
+This section specifies the conformance levels of this standard. The conformance levels offer implementers several levels of conformance. These can be used to establish competitive differentiation.
 
 This document defines the conformance levels of a BPI as follows:
 * **Level 1:** All MUST requirements are fulfilled by a specific implementation as proven by a test report that proves in an easily understandable manner the implementation's conformance with each requirement based on implementation-specific test-fixtures with implementation-specific test-fixture inputs.
 * **Level 2:** All MUST and SHOULD requirements are fulfilled by a specific implementation as proven by a test report that proves in an easily understandable manner the implementation's conformance with each requirement based on implementation-specific test-fixtures with implementation-specific test-fixture inputs.
 * **Level 3:** All MUST, SHOULD, and MAY requirements with conditional MUST or SHOULD requirements are fulfilled by a specific implementation as proven by a test report that proves in an easily understandable manner the implementation's conformance with each requirement based on implementation-specific test-fixtures with implementation-specific test-fixture inputs.
-* **Level 4:** All MUST requirements are fulfilled by a specific implementation as proven by the test report defined in this document that proves the implementation's conformance with each requirement based on test-fixtures with test-fixture inputs as defined in this document. **This conformance level cannot yet be achieved since there is not yet a defined set of standardized test-fixtures and test-inputs**.
-* **Level 5:** All MUST and SHOULD requirements are fulfilled by a specific implementation as proven by the test report defined in this document that proves the implementation's conformance with each requirement based on test-fixtures with test-fixture inputs as defined in this document. **This conformance level cannot yet be achieved since there is not yet a defined set of standardized test-fixtures and test-inputs**.
-* **Level 6:** All MUST, SHOULD, and MAY requirements with conditional MUST or SHOULD requirements are fulfilled by a specific implementation as proven by the test report defined in this document that proves the implementation's conformance with each requirement based on test-fixtures with test-fixture inputs as defined in this document. **This conformance level cannot yet be achieved since there is not yet a defined set of standardized test-fixtures and test-inputs**.
+
+#### **[D43]** 
+A claim that a BPI conforms to this specification SHOULD describe the testing procedure used to justify the claim.
+
+#### **[R319]** 
+A claim that a BPI conforms to this specification at **level 2** or higher MUST describe the testing procedure used to justify the claim.
 
 Note that BPI Integration requirements in section [5.5.4 Bi- and Multi-directional and Mono-directional BPI Interoperability Services](#554-bi--and-multi-directional-and-mono-directional-bpi-interoperability-services) and section [5.6 Standardized Set of BPI Interoperability APIs](#56-standardized-set-of-bpi-interoperability-apis) are not mandatory for meeting conformance until there are at least two implementations conformant to Level 1 of this standards' requirements.
 


### PR DESCRIPTION
Removes levels 4-6, as discussed 9? December

Adds two new requirements:
**[D43]**  - a should requirement that all conformance claims describe the justification of the claim

**[R319]** - a MUST requirement for claims of conformance to **level 2** or higher conformance.

Strictly the second requirement is redundant, since meeting **level 2** requires meeting **[D43]**. Not sure how obvious that is, but I'd be happy to remove this requirement, perhaps instead pointing out in a note that it will effectively apply...

closes #99