### PR TITLE
Merge R6 and R7

### DIFF
--- a/core/baseline-core-v1.0-psd01.md
+++ b/core/baseline-core-v1.0-psd01.md
@@ -474,10 +474,7 @@ A commercial State Object to be transacted on MUST be based on a specific commer
 A commercial document MUST be derived from a legally binding contract.
 
 #### **[R6]**	
-A commercial document MUST be represented as an electronic record.
-
-#### **[R7]**  
-A commercial document MUST be represented on a BPI between the counterparties.
+A commercial document MUST be represented as an electronic record on a BPI between the counterparties.
 
 #### **[R8]**	
 A commercial document MUST be authorized by legal representatives of the parties or their legal delegates.


### PR DESCRIPTION
fixes #117

If there is no commercial document, R7 was meaningless and so unnecessary. While in principle an electronic version not represented in the BPI still has some utility, it doesn't seem like it's sufficient to meet the requirements of a decent system.

I didn't renumber the requirements. First because it's a massive amount of work and it isn't clear if this PR will be accepted in principle, and second because it seems possible that other requirements are changed. (I would suggest using names instead of just numbers, such as R-commdoc-in-bpi, to minimise the problem, but that's a purely editorial decision).