### PR TITLE
Update CodeOwners - Remove inactive standard maintainer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,4 +6,4 @@
 # the repo. Unless a later match takes precedence,
 # the following owers will be requested for
 # review when someone opens a pull request.
-*       @kthomas @Therecanbeonlyone1969 @humbitious @Ybittan @chaals
+*       @kthomas @Therecanbeonlyone1969 @Ybittan @chaals

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,6 +4,6 @@
 
 # These owners will be the default owners for everything in
 # the repo. Unless a later match takes precedence,
-# the following owers will be requested for
+# the following owners will be requested for
 # review when someone opens a pull request.
 *       @kthomas @Therecanbeonlyone1969 @Ybittan @chaals


### PR DESCRIPTION
Remove inactive standard maintainer to keep requested maintainers up to date. 

Please resubmit request to once active.