### PR TITLE
Adds Internationalization and Localization Reference

### DIFF
--- a/api/baseline-api-v1.0-psd01.md
+++ b/api/baseline-api-v1.0-psd01.md
@@ -635,7 +635,7 @@ Creates a BPI `SubjectAccount` for a specified BPI `Subject`.
 ```
 #### **[R11]**
 
-Returns details for a specific BPI `SubjectAccount` for a specified BPI `Subject`.
+Returns details of the BPI `SubjectAccount` when given a specified BPI `Subject`.
 
 ```
   /subjects/{subject_id}/accounts/{id}:

--- a/api/baseline-api-v1.0-psd01.md
+++ b/api/baseline-api-v1.0-psd01.md
@@ -4255,3 +4255,5 @@ Revisions made since the initial stage of this numbered Version of this document
 #### **[OAuth-2.0]** 
 Aaron Parecki, (2020), “OAuth 2.0 Simplified”, ISBN-13: 978-1387751518.
 
+## C.1 Internationalization and Localization Reference
+The standard encourages implementers to follow the [W3C "Strings on the Web: Language and Direction Metadata" best practices guide](#W3C-String-Meta) for identifying language and base direction for strings used on the Web wherever appropriate. 

--- a/ccsm/baseline-ccsm-v1.0-psd01.md
+++ b/ccsm/baseline-ccsm-v1.0-psd01.md
@@ -202,7 +202,7 @@ There are four requirement levels that are coded in requirement ids as per below
 
 Note that requirements are uniquely numbered in ascending order within each requirement level.
 
-Example : It should be read that [R1] is an absolute requirement of the specification whereas [D1] is a recommendation.
+Example: It should be read that [R1] is an absolute requirement of the specification whereas [D1] is a recommendation.
 
 
 -------

--- a/ccsm/baseline-ccsm-v1.0-psd01.md
+++ b/ccsm/baseline-ccsm-v1.0-psd01.md
@@ -477,6 +477,9 @@ Recommendations of the National Institute of Standards and Technology (NIST Guid
 #### **[HSM]** 
 Ramakrishnan, Vignesh; Venugopal, Prasanth; Mukherjee, Tuhin (2015). Proceedings of the International Conference on Information Engineering, Management and Security 2015: ICIEMS 2015. Association of Scientists, Developers and Faculties (ASDF). p. 9. ISBN 9788192974279.
 
+## A.3 Internationalization and Localization Reference
+The standard encourages implementers to follow the [W3C "Strings on the Web: Language and Direction Metadata" best practices guide](#W3C-String-Meta) for identifying language and base direction for strings used on the Web wherever appropriate. 
+
 
 -------
 

--- a/core/baseline-core-v1.0-psd01.md
+++ b/core/baseline-core-v1.0-psd01.md
@@ -3150,6 +3150,9 @@ The standard does not set any requirements for compliance to jurisdiction legisl
 
 The standard does not set any requirements for the use of specific applications/tools/libraries etc. The implementer should perform due diligence when selecting specific applications/tools/libraries.
 
+## B.3 Internationalization and Localization Reference
+The standard encourages implementers to follow the [W3C "Strings on the Web: Language and Direction Metadata" best practices guide](#W3C-String-Meta) for identifying language and base direction for strings used on the Web wherever appropriate. 
+
 <!--
 
 (Note: OASIS strongly recommends that Open Projects consider issues that might affect safety, security, privacy, and/or data protection in implementations of their specification and document them for implementers and adopters. For some purposes, you may find it required, e.g. if you apply for IANA registration.


### PR DESCRIPTION
Created an A.3 section within Appendix A - References and included a reference to w3c
Chose this section as it seems the most relevant without having to create a new section and re-order things that could potentially interfere with linking. 

This PR also includes a slight wording change to a requirement in the API spec. 